### PR TITLE
Fix spinning cursor on OS X

### DIFF
--- a/nes/azul3d_audio.go
+++ b/nes/azul3d_audio.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"unsafe"
 
-	"azul3d.org/native/al.v1"
+	"azul3d.org/native/al.v1-dev"
 )
 
 type Azul3DAudio struct {

--- a/nes/azul3d_video.go
+++ b/nes/azul3d_video.go
@@ -265,9 +265,9 @@ func (video *Azul3DVideo) Run() {
 		card.Textures = []*gfx.Texture{nil}
 		card.Meshes = []*gfx.Mesh{cardMesh}
 
-		updateTex := func() {
-			img := image.NewPaletted(image.Rect(0, 0, 256, 240), video.palette)
+		img := image.NewPaletted(image.Rect(0, 0, 256, 240), video.palette)
 
+		updateTex := func() {
 			x, y := 0, 0
 
 			for _, c := range colors {


### PR DESCRIPTION
- Fix the spinning cursor / UI deadlock on OS X.
- Make less memory allocations when updating the texture / video display.
- A better OpenAL usage (no flushing, better buffering on channels, and a re syncing pattern).

This does not stop the clicking issue entirely.