### PR TITLE
nes: implement an APU debug audio backend.

### DIFF
--- a/nes/apudebug_audio.go
+++ b/nes/apudebug_audio.go
@@ -1,0 +1,66 @@
+// +build sdl,apudebug
+
+package nes
+
+import (
+	"fmt"
+	"time"
+)
+
+type APUDebugAudio struct {
+	frequency  int
+	sampleSize int
+	input      chan int16
+}
+
+func NewAudio(frequency int, sampleSize int) (audio *APUDebugAudio, err error) {
+	audio = &APUDebugAudio{
+		frequency:  frequency,
+		sampleSize: sampleSize,
+		input:      make(chan int16),
+	}
+	return
+}
+
+func (audio *APUDebugAudio) Input() chan int16 {
+	return audio.input
+}
+
+func (audio *APUDebugAudio) Run() {
+	print := time.NewTicker(1 * time.Second)
+	start := time.Now()
+	samples := 0
+	for {
+		select {
+		case <-audio.input:
+			samples++
+		case <-print.C:
+			t := time.Since(start)
+			fmt.Println("\nAPU DEBUG:")
+			fmt.Println("Total samples:", samples)
+			fmt.Println("Total time:", t)
+			fmt.Printf("%f samples/sec\n", float64(samples)/t.Seconds())
+		}
+	}
+	/*
+		i := 0
+
+		for {
+			select {
+			case s := <-audio.input:
+				audio.samples[i] = s
+
+				if i++; i == len(audio.samples) {
+					sdl_audio.SendAudio_int16(audio.samples)
+					i = 0
+				}
+			}
+		}
+	*/
+}
+
+func (audio *APUDebugAudio) TogglePaused() {
+}
+
+func (audio *APUDebugAudio) Close() {
+}

--- a/nes/azul3d_audio.go
+++ b/nes/azul3d_audio.go
@@ -1,4 +1,4 @@
-// +build !sdl
+// +build !sdl,!apudebug
 
 package nes
 

--- a/nes/nes.go
+++ b/nes/nes.go
@@ -380,7 +380,7 @@ func (nes *NES) Run() (err error) {
 		go nes.audioRecorder.Run()
 	}
 
-	// runtime.LockOSThread()
+	runtime.LockOSThread()
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	if nes.options.CPUProfile != "" {

--- a/nes/sdl_audio.go
+++ b/nes/sdl_audio.go
@@ -1,4 +1,4 @@
-// +build sdl
+// +build sdl,!apudebug
 
 // adapted from github.com/scottferg/Fergulator/audio.go
 


### PR DESCRIPTION
To use the debug backend build/install using the build tags
"sdl" AND "apudebug". For example:

  go build -tags "sdl apudebug"

It will print every second how many samples the APU has created,
the total time that has passed, and the samples per second. On my
old laptop for example:

  APU DEBUG:
  Total samples: 106595
  Total time: 3.000063835s
  35530.910628 samples/sec

  APU DEBUG:
  Total samples: 140324
  Total time: 4.000065022s
  35080.429750 samples/sec

  APU DEBUG:
  Total samples: 170463
  Total time: 5.000062647s
  34092.172846 samples/sec

Where 34092.172846 samples/sec directly relates to e.g. 34khz audio.
