### PR TITLE
Fix audio clicking problem.

### DIFF
--- a/nes/azul3d_audio.go
+++ b/nes/azul3d_audio.go
@@ -155,9 +155,9 @@ func (audio *Azul3DAudio) Run() {
 			}
 
 			handler(audio.bufferData(pbuffers[i], samples))
+			audio.device.SourceQueueBuffers(audio.source, []uint32{pbuffers[i]})
 			samples = nil
 		}
-		audio.device.SourceQueueBuffers(audio.source, pbuffers)
 
 		// Begin playing the source now that we've filled all the buffers.
 		if audio.device.GetSourcei(audio.source, al.SOURCE_STATE, &state); state != al.PLAYING {


### PR DESCRIPTION
These two commits entirely solve the audio clicking on my faster system.

The underlying problem was that `runProcessors` needs to be decoupled from the video display, or else `runProcessors` is limited to 60hz which isn't fast enough to generate the needed 44.1khz audio samples.

From the testing I've done, I still seem to get perfectly smooth video playback at a steady 60FPS and I get smooth audio as well.