### PR TITLE
State Save/Load cleanup

### DIFF
--- a/nes/rom.go
+++ b/nes/rom.go
@@ -54,14 +54,6 @@ type ROMFile struct {
 	VROMBanks   [][]uint8
 	irq         func(state bool)
 	setTables   func(t0, t1, t2, t3 int)
-	raw         []byte
-}
-
-type ROMFileRaw struct {
-	WRAMBanks [][]uint8
-	ROMBanks  [][]uint8
-	VROMBanks [][]uint8
-	Raw       []byte
 }
 
 type ROM interface {
@@ -71,7 +63,6 @@ type ROM interface {
 	GameName() string
 	LoadBattery()
 	SaveBattery() (err error)
-	GetRaw() *ROMFileRaw
 	GetROMFile() *ROMFile
 }
 
@@ -290,7 +281,6 @@ func NewROMFile(buf []byte) (romf *ROMFile, err error) {
 		romf.WRAMBanks[n] = make([]uint8, offset)
 	}
 
-	romf.raw = buf
 	return
 }
 
@@ -370,15 +360,6 @@ func (romf *ROMFile) SaveBattery() (err error) {
 	err = ioutil.WriteFile(savename, buf.Bytes(), 0644)
 
 	return
-}
-
-func (romf *ROMFile) GetRaw() *ROMFileRaw {
-	return &ROMFileRaw{
-		WRAMBanks: romf.WRAMBanks,
-		ROMBanks:  romf.ROMBanks,
-		VROMBanks: romf.VROMBanks,
-		Raw:       romf.raw,
-	}
 }
 
 func (romf *ROMFile) GetROMFile() *ROMFile {

--- a/nes/rom.go
+++ b/nes/rom.go
@@ -115,8 +115,17 @@ func getBuf(filename string) (buf []byte, suffix string, err error) {
 	return
 }
 
-func NewROMFromRaw(gamename string, raw []byte, irq func(state bool), setTables func(t0, t1, t2, t3 int)) (rom ROM, err error) {
-	romf, err := NewROMFile(raw)
+func NewROM(filename string, irq func(state bool), setTables func(t0, t1, t2, t3 int)) (rom ROM, err error) {
+	var buf []byte
+	var suffix string
+
+	buf, suffix, err = getBuf(filename)
+
+	if err != nil {
+		return
+	}
+
+	romf, err := NewROMFile(buf)
 
 	if err != nil {
 		return
@@ -126,7 +135,7 @@ func NewROMFromRaw(gamename string, raw []byte, irq func(state bool), setTables 
 	romf.setTables = setTables
 
 	romf.setTables(romf.Tables())
-	romf.Gamename = gamename
+	romf.Gamename = strings.TrimSuffix(filename, suffix)
 
 	switch romf.Mapper {
 	case 0x00, 0x40, 0x41:
@@ -147,21 +156,6 @@ func NewROMFromRaw(gamename string, raw []byte, irq func(state bool), setTables 
 		err = errors.New(fmt.Sprintf("Unsupported mapper type %v", romf.Mapper))
 	}
 
-	return
-}
-
-func NewROM(filename string, irq func(state bool), setTables func(t0, t1, t2, t3 int)) (rom ROM, err error) {
-	var buf []byte
-	var suffix string
-
-	buf, suffix, err = getBuf(filename)
-
-	if err != nil {
-		return
-	}
-
-	gamename := strings.TrimSuffix(filename, suffix)
-	rom, err = NewROMFromRaw(gamename, buf, irq, setTables)
 	return
 }
 


### PR DESCRIPTION
Now SaveState always save ROM data, so LoadStateEvent can restore the whole NES environment.

As we have to send a LoadStateEvent to slave any way, adding a separate logic to the event loop to setup state in slave looks redundant in this version.

Any comments?